### PR TITLE
Update InventoryCraftingExtensions.kt

### DIFF
--- a/src/main/kotlin/aurocosh/divinefavor/common/lib/extensions/InventoryCraftingExtensions.kt
+++ b/src/main/kotlin/aurocosh/divinefavor/common/lib/extensions/InventoryCraftingExtensions.kt
@@ -7,4 +7,4 @@ fun InventoryCrafting.asSequence(): Sequence<ItemStack> {
     return indices.S.map(this::getStackInSlot)
 }
 
-val InventoryCrafting.indices: IntRange get() = (0..this.sizeInventory)
+val InventoryCrafting.indices: IntRange get() = (0..(this.sizeInventory-1))


### PR DESCRIPTION
Off by 1 error causing conflict with crafting stations mod when one tries to check slot with index of 9 when the last slot index is 8:
```
java.lang.RuntimeException: Slot 9 not in valid range - [0,9)
    at net.minecraftforge.items.ItemStackHandler.validateSlotIndex(ItemStackHandler.java:214)
    at net.minecraftforge.items.ItemStackHandler.getStackInSlot(ItemStackHandler.java:73)
    at com.tfar.craftingstation.CraftingInventoryPersistant.getStackInSlot(CraftingInventoryPersistant.java:30)
    at aurocosh.divinefavor.common.lib.extensions.InventoryCraftingExtensionsKt$asSequence$1.invoke(InventoryCraftingExtensions.kt:7)
```